### PR TITLE
Fix t bin for the TOF exponential distribution 

### DIFF
--- a/antea/elec/tof_functions.py
+++ b/antea/elec/tof_functions.py
@@ -37,14 +37,14 @@ def convolve_tof(spe_response: Sequence[float],
     """
     if not np.count_nonzero(spe_response):
         print('spe_response values are zero')
-        return np.zeros(len(spe_response)+len(signal)-1)
-    conv_first = np.hstack([spe_response, np.zeros(len(signal)-1)])
-    conv_res   = np.zeros(len(signal)+len(spe_response)-1)
+        return np.zeros(len(spe_response)+len(signal))
+    conv_first = np.hstack([spe_response, np.zeros(len(signal))])
+    conv_res   = np.zeros(len(signal)+len(spe_response))
     pe_pos     = np.argwhere(signal > 0)
     pe_recov   = signal[pe_pos]
     for i in range(len(pe_recov)): #Loop over the charges
         conv_first_ch = conv_first*pe_recov[i]
-        desp          = np.roll(conv_first_ch, pe_pos[i])
+        desp          = np.roll(conv_first_ch, pe_pos[i]-1)
         conv_res     += desp
     return conv_res
 

--- a/antea/elec/tof_functions_test.py
+++ b/antea/elec/tof_functions_test.py
@@ -46,7 +46,7 @@ def test_convolve_tof(l, s):
     """
     spe_response, norm = tf.apply_spe_dist(np.unique(np.array(l)), tau_sipm)
     conv_res           = tf.convolve_tof(spe_response, np.array(s))
-    assert len(conv_res) == len(spe_response) + len(s) - 1
+    assert len(conv_res) == len(spe_response) + len(s)
     if np.count_nonzero(spe_response):
         assert np.isclose(np.sum(s), np.sum(conv_res))
 
@@ -70,7 +70,7 @@ def test_tdc_convolution(ANTEADATADIR, filename):
         tof_sns = evt_tof.sensor_id.unique()
         for s_id in tof_sns:
             tdc_conv = tf.tdc_convolution(tof_response, spe_resp, s_id, time_window)
-            assert len(tdc_conv) == time_window + len(spe_resp) - 1
+            assert len(tdc_conv) == time_window + len(spe_resp)
             if len(tof_response[(tof_response.sensor_id == s_id) &
                             (tof_response.time_bin > time_window)]) == 0:
                 assert np.count_nonzero(tdc_conv) > 0

--- a/antea/elec/tof_functions_test.py
+++ b/antea/elec/tof_functions_test.py
@@ -70,7 +70,7 @@ def test_tdc_convolution(ANTEADATADIR, filename):
         evt_tof = tof_response[tof_response.event_id == evt]
         tof_sns = evt_tof.sensor_id.unique()
         for s_id in tof_sns:
-            tdc_conv = tf.tdc_convolution(tof_response, spe_resp, s_id, time_window)
+            tdc_conv = tf.tdc_convolution(evt_tof, spe_resp, s_id, time_window)
             assert len(tdc_conv) == time_window + len(spe_resp)
             if len(tof_response[(tof_response.sensor_id == s_id) &
                             (tof_response.time_bin > time_window)]) == 0:

--- a/antea/elec/tof_functions_test.py
+++ b/antea/elec/tof_functions_test.py
@@ -112,7 +112,7 @@ def test_first_bin_is_the_same_after_convolution(ANTEADATADIR):
     """
     PATH_IN          = os.path.join(ANTEADATADIR, 'full_body_1ev.h5')
     tof_response     = load_mcTOFsns_response(PATH_IN)
-    evt              = tof_response.event_id .unique() #The datafile contains only 1 event
+    evt              = tof_response.event_id .unique()[0] #The datafile contains only 1 event
     tof_sns          = tof_response.sensor_id.unique()
     for s_id in tof_sns:
         tdc_conv    = tf.tdc_convolution(tof_response, spe_resp, s_id, time_window)

--- a/antea/elec/tof_functions_test.py
+++ b/antea/elec/tof_functions_test.py
@@ -15,7 +15,8 @@ l        = st.lists(st.integers(min_value=1, max_value=10000), min_size=2, max_s
 @given(l)
 def test_apply_spe_dist(l):
     """
-    This test checks that the function apply_spe_dist returns an array with the distribution value for each time.
+    This test checks that the function apply_spe_dist returns an array with the
+    distribution value for each time.
     """
     l = np.array(l)
     exp_dist, norm_dist = tf.apply_spe_dist(np.unique(l), tau_sipm)
@@ -31,7 +32,8 @@ def test_apply_spe_dist(l):
                    (np.array([1,2,3]), np.array([0.01029012, 0.02047717, 0.03056217]))))
 def test_spe_dist(time, time_dist):
     """
-    Spe_dist is an analitic function, so this test takes some values and checks that the function returns the correct value for each one.
+    Spe_dist is an analitic function, so this test takes some values and checks
+    that the function returns the correct value for each one.
     """
     result = tf.spe_dist(time, tau_sipm)
     assert np.all(result) == np.all(time_dist)
@@ -42,7 +44,9 @@ s = st.lists(st.integers(min_value=1, max_value=10000), min_size=2, max_size=100
 @given(l, s)
 def test_convolve_tof(l, s):
     """
-    Check that the function convolve_tof returns an array with the adequate length, and, in case the array is not empty, checks that the convoluted signal is normalizated to the initial signal.
+    Check that the function convolve_tof returns an array with the adequate length, and,
+    in case the array is not empty, checks that the convoluted signal is normalizated
+    to the initial signal.
     """
     spe_response, norm = tf.apply_spe_dist(np.unique(np.array(l)), tau_sipm)
     conv_res           = tf.convolve_tof(spe_response, np.array(s))
@@ -61,7 +65,8 @@ spe_resp, norm = tf.apply_spe_dist(time, tau_sipm)
                    ('full_body_1ev.h5')))
 def test_tdc_convolution(ANTEADATADIR, filename):
     """
-    Check that the function tdc_convolution returns a table with the adequate dimensions and in case the tof dataframe is empty, checks that the table only contains zeros.
+    Check that the function tdc_convolution returns a table with the adequate dimensions
+    and in case the tof dataframe is empty, checks that the table only contains zeros.
     """
     PATH_IN        = os.path.join(ANTEADATADIR, filename)
     tof_response   = load_mcTOFsns_response(PATH_IN)
@@ -84,7 +89,9 @@ l2    = st.lists(st.floats(min_value=0, max_value=1000), min_size=2, max_size=10
 @given(e, s_id, l2)
 def test_translate_charge_conv_to_wf_df(e, s_id, l2):
     """
-    Look whether the translate_charge_conv_to_wf_df function returns a dataframe with the same number of rows as the input numpy array and four columns. Three of this columns must contain integers.
+    Look whether the translate_charge_conv_to_wf_df function returns a dataframe
+    with the same number of rows as the input numpy array and four columns.
+    Three of this columns must contain integers.
     """
     l2    = np.array(l2)
     wf_df = tf.translate_charge_conv_to_wf_df(e, s_id, l2)


### PR DESCRIPTION
In the old version of the function `convolve_tof` there was a small bug introducing a difference of one bin in the t bin for the `tof_response` table. This bug has been solved and a tests has been included to check that the first time bin for every sensor remains the same after applying the exponential distribution.