### PR TITLE
New tables for PetBox geometry

### DIFF
--- a/antea/conftest.py
+++ b/antea/conftest.py
@@ -32,8 +32,9 @@ def output_tmpdir(tmpdir_factory):
 
 
 @pytest.fixture(scope='session',
-                params=[db_data('petalo' ,  3500)],
-                ids=["petit"])
+                params=[db_data('petalo' ,  3500),
+                        db_data('petbox' ,    80)],
+                ids=["petit", "petbox"])
 def db(request):
     return request.param
 

--- a/antea/conftest.py
+++ b/antea/conftest.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 
 from invisible_cities.core import system_of_units as units
 
-db_data  = namedtuple('db_data', 'detector nsipms')
+db_data  = namedtuple('db_data', 'detector nsipms conf_label')
 
 
 @pytest.fixture(scope = 'session')
@@ -32,15 +32,15 @@ def output_tmpdir(tmpdir_factory):
 
 
 @pytest.fixture(scope='session',
-                params=[db_data('petalo' ,  3500),
-                        db_data('petbox' ,    80)],
+                params=[db_data('petalo' ,  3500, 'P7R195Z140mm'),
+                        db_data('petalo' ,   128, 'PB')],
                 ids=["petit", "petbox"])
 def db(request):
     return request.param
 
 
 @pytest.fixture(scope='session',
-                params=[db_data('petalo' ,  102304)],
+                params=[db_data('petalo' ,  102304, 'P7R410Z1950mm')],
                 ids=["sim-only"])
 def db_sim_only(request):
     return request.param

--- a/antea/database/download.py
+++ b/antea/database/download.py
@@ -7,7 +7,7 @@ import re
 from os import path
 
 
-tables = ['ChannelPositionP7R195Z140mm', 'ChannelGainP7R195Z140mm', 'ChannelMaskP7R195Z140mm', 'ChannelMappingP7R195Z140mm', 'ChannelMatrixP7R195Z140mm', 'ChannelPositionP7R410Z1950mm', 'ChannelGainP7R410Z1950mm', 'ChannelMatrixP7R410Z1950mm']
+tables = ['ChannelPositionP7R195Z140mm', 'ChannelGainP7R195Z140mm', 'ChannelMaskP7R195Z140mm', 'ChannelMappingP7R195Z140mm', 'ChannelPositionP7R410Z1950mm', 'ChannelGainP7R410Z1950mm', 'ChannelMatrixP7R410Z1950mm', 'ChannelPositionPB', 'ChannelGainPB', 'ChannelMaskPB', 'ChannelMappingPB']
 
 
 def create_table_sqlite(cursorSqlite, cursorMySql, table):

--- a/antea/database/load_db.py
+++ b/antea/database/load_db.py
@@ -21,17 +21,16 @@ def DataSiPM(db_file, run_number=1e5, conf_label='P7R195Z140mm'):
 
     conn = sqlite3.connect(get_db(db_file))
 
-    sql = '''select pos.SensorID, map.ElecID "ChannelID",
+    sql = '''select pos.SensorID, map.CardID, map.TofpetID, map.ChannelID,
 case when msk.SensorID is NULL then 1 else 0 end "Active",
-X, Y, Z, Centroid "adc_to_pes", Sigma, PhiNumber, ZNumber
+X, Y, Z, Centroid "adc_to_pes", Sigma
 from ChannelPosition{0} as pos INNER JOIN ChannelGain{0} as gain
 ON pos.SensorID = gain.SensorID INNER JOIN ChannelMapping{0} as map
-ON pos.SensorID = map.SensorID INNER JOIN ChannelMatrix{0} as mtrx
-ON pos.SensorID = mtrx.SensorID LEFT JOIN
+ON pos.SensorID = map.SensorID LEFT JOIN
 (select * from ChannelMask{0} where MinRun <= {1} and {1} <= MaxRun) as msk
 where pos.MinRun <= {1} and {1} <= pos.MaxRun
 and gain.MinRun <= {1} and {1} <= gain.MaxRun
-and mtrx.MinRun <= {1} and {1} <= mtrx.MaxRun
+and map.MinRun <= {1} and {1} <= map.MaxRun
 order by pos.SensorID
 '''.format(conf_label, abs(run_number))
     data = pd.read_sql_query(sql, conn)

--- a/antea/database/load_db_test.py
+++ b/antea/database/load_db_test.py
@@ -14,7 +14,7 @@ from . import load_db as DB
 def test_sipm_pd(db):
     """Check that we retrieve the correct number of SiPMs."""
     sipms = DB.DataSiPM(db.detector)
-    columns = ['SensorID', 'ChannelID', 'Active', 'X', 'Y', 'Z', 'adc_to_pes', 'Sigma', 'PhiNumber', 'ZNumber']
+    columns = ['SensorID', 'CardID', 'TofpetID', 'ChannelID', 'Active', 'X', 'Y', 'Z', 'adc_to_pes', 'Sigma']
     assert columns == list(sipms)
     assert sipms.shape[0] == db.nsipms
 

--- a/antea/database/load_db_test.py
+++ b/antea/database/load_db_test.py
@@ -13,7 +13,7 @@ from . import load_db as DB
 
 def test_sipm_pd(db):
     """Check that we retrieve the correct number of SiPMs."""
-    sipms = DB.DataSiPM(db.detector)
+    sipms = DB.DataSiPM(db.detector, conf_label=db.conf_label)
     columns = ['SensorID', 'CardID', 'TofpetID', 'ChannelID', 'Active', 'X', 'Y', 'Z', 'adc_to_pes', 'Sigma']
     assert columns == list(sipms)
     assert sipms.shape[0] == db.nsipms
@@ -28,4 +28,6 @@ def test_sipm_pd_sim_only(db_sim_only):
 
 
 def test_mc_runs_equal_data_runs(db):
-    assert (DB.DataSiPM(db.detector, -3550).values == DB.DataSiPM(db.detector, 3550).values).all()
+    db1 = DB.DataSiPM(db.detector, -3550, conf_label=db.conf_label).values
+    db2 = DB.DataSiPM(db.detector,  3550, conf_label=db.conf_label).values
+    assert (db1 == db2).all()

--- a/antea/database/localdb.PETALODB.sqlite3
+++ b/antea/database/localdb.PETALODB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3f142610f425f399b3375302bd2509d9c1bd3d36cbe70d4f8774992c2cc07148
-size 9732096
+oid sha256:aba952fceeabcc58a767a254e7baf6588a9938bb130fa7936f2c4f5c9456500e
+size 9695232


### PR DESCRIPTION
This PR adds new tables to the database related to the PetBox geometry (a.k.a _cajita_). It also modifies the code to read the new tables.
Some modifications to the old tables of the ring geometry were needed, to be able to use the same function for loading. Since this geometry is obsolete, the modifications are not relevant. We decided not to delete this geometry because many tests rely on it.