### PR TITLE
Add the possibility of simulating only photoelectric coincidences

### DIFF
--- a/antea/mcsim/fastmc.py
+++ b/antea/mcsim/fastmc.py
@@ -11,7 +11,18 @@ from invisible_cities.core import system_of_units as units
 
 from antea.mcsim.errmat import errmat
 import antea.reco.reco_functions as rf
-from antea.mcsim.fastmc3d import get_reco_interaction
+
+def get_reco_interaction(r: float, phi: float, z: float, t: float,
+                         errmat_r: errmat, errmat_phi: errmat, errmat_z: errmat, errmat_t: errmat):
+    """
+    Extract the spatial coordinates and time for one interaction, using error matrices.
+    """
+    reco_r   = errmat_r.get_random_error(r)
+    reco_phi = errmat_phi.get_random_error(phi)
+    reco_z   = errmat_z.get_random_error(z)
+    reco_t   = errmat_t.get_random_error(t)
+
+    return reco_r, reco_phi, reco_z, reco_t
 
 
 def simulate_reco_event(evt_id: int, hits: pd.DataFrame, particles: pd.DataFrame,

--- a/antea/mcsim/fastmc.py
+++ b/antea/mcsim/fastmc.py
@@ -30,7 +30,8 @@ def simulate_reco_event(evt_id: int, hits: pd.DataFrame, particles: pd.DataFrame
                         errmat_p_r: errmat, errmat_p_phi: errmat, errmat_p_z: errmat,
                         errmat_p_t: errmat, errmat_c_r: errmat, errmat_c_phi: errmat,
                         errmat_c_z: errmat, errmat_c_t: errmat,
-                        true_e_threshold: float = 0., photo_range: float = 1.) -> pd.DataFrame:
+                        true_e_threshold: float = 0., photo_range: float = 1.,
+                        only_phot: bool = False) -> pd.DataFrame:
     """
     Simulate the reconstructed coordinates for 1 coincidence from true GEANT4 dataframes.
     Notice that the time binning must be provided in ps.
@@ -65,7 +66,9 @@ def simulate_reco_event(evt_id: int, hits: pd.DataFrame, particles: pd.DataFrame
 
     pos1, pos2, t1, t2, phot1, phot2 = rf.find_first_interactions_in_active(evt_parts, evt_hits, photo_range)
 
-    if len(pos1) == 0 or len(pos2) == 0:
+    no_reco_positions = len(pos1) == 0 or len(pos2) == 0
+    no_phot_interactions = not phot1 or not phot2
+    if no_reco_positions or (only_phot and no_phot_interactions):
         events = pd.DataFrame({'event_id':  [float(evt_id)],
                                'true_energy': [energy],
                                'true_r1':   [0.],

--- a/antea/mcsim/fastmc.py
+++ b/antea/mcsim/fastmc.py
@@ -11,19 +11,7 @@ from invisible_cities.core import system_of_units as units
 
 from antea.mcsim.errmat import errmat
 import antea.reco.reco_functions as rf
-
-
-def get_reco_interaction(r: float, phi: float, z: float, t: float,
-                         errmat_r: errmat, errmat_ph: errmati, errmat_z: errmat, errmat_t: errmat):
-    """
-    Extract the spatial coordinates and time for one interaction, using error matrices.
-    """
-    reco_r   = errmatr.get_random_error(r)
-    reco_phi = errmat_phi.get_random_error(phi)
-    reco_z   = errmat_z.get_random_error(z)
-    reco_t   = errmat_t.get_random_error(t)
-
-    return reco_r, reco_phi, reco_z, reco_t
+from antea.mcsim.fastmc3d import get_reco_interaction
 
 
 def simulate_reco_event(evt_id: int, hits: pd.DataFrame, particles: pd.DataFrame,

--- a/antea/mcsim/fastmc.py
+++ b/antea/mcsim/fastmc.py
@@ -17,10 +17,10 @@ def get_reco_interaction(r: float, phi: float, z: float, t: float,
     """
     Extract the spatial coordinates and time for one interaction, using error matrices.
     """
-    reco_r   = errmat_r.get_random_error(r)
+    reco_r   = errmat_r  .get_random_error(r)
     reco_phi = errmat_phi.get_random_error(phi)
-    reco_z   = errmat_z.get_random_error(z)
-    reco_t   = errmat_t.get_random_error(t)
+    reco_z   = errmat_z  .get_random_error(z)
+    reco_t   = errmat_t  .get_random_error(t)
 
     return reco_r, reco_phi, reco_z, reco_t
 

--- a/antea/mcsim/fastmc.py
+++ b/antea/mcsim/fastmc.py
@@ -12,6 +12,20 @@ from invisible_cities.core import system_of_units as units
 from antea.mcsim.errmat import errmat
 import antea.reco.reco_functions as rf
 
+
+def get_reco_interaction(r: float, phi: float, z: float, t: float,
+                         errmat_r: errmat, errmat_ph: errmati, errmat_z: errmat, errmat_t: errmat):
+    """
+    Extract the spatial coordinates and time for one interaction, using error matrices.
+    """
+    reco_r   = errmatr.get_random_error(r)
+    reco_phi = errmat_phi.get_random_error(phi)
+    reco_z   = errmat_z.get_random_error(z)
+    reco_t   = errmat_t.get_random_error(t)
+
+    return reco_r, reco_phi, reco_z, reco_t
+
+
 def simulate_reco_event(evt_id: int, hits: pd.DataFrame, particles: pd.DataFrame,
                         errmat_p_r: errmat, errmat_p_phi: errmat, errmat_p_z: errmat,
                         errmat_p_t: errmat, errmat_c_r: errmat, errmat_c_phi: errmat,
@@ -90,26 +104,15 @@ def simulate_reco_event(evt_id: int, hits: pd.DataFrame, particles: pd.DataFrame
 
     # Get all errors.
     if phot1:
-        er1   = errmat_p_r.get_random_error(r1)
-        ephi1 = errmat_p_phi.get_random_error(phi1)
-        ez1   = errmat_p_z.get_random_error(z1)
-        et1   = errmat_p_t.get_random_error(t1)
+        er1, ephi1, ez1, et1 = get_reco_interaction(r1, phi1, z1, t1, errmat_p_r, errmat_p_phi, errmat_p_z, errmat_p_t)
     else:
-        er1   = errmat_c_r.get_random_error(r1)
-        ephi1 = errmat_c_phi.get_random_error(phi1)
-        ez1   = errmat_c_z.get_random_error(z1)
-        et1   = errmat_c_t.get_random_error(t1)
+        er1, ephi1, ez1, et1 = get_reco_interaction(r1, phi1, z1, t1, errmat_c_r, errmat_c_phi, errmat_c_z, errmat_c_t)
 
     if phot2:
-        er2   = errmat_p_r.get_random_error(r2)
-        ephi2 = errmat_p_phi.get_random_error(phi2)
-        ez2   = errmat_p_z.get_random_error(z2)
-        et2   = errmat_p_t.get_random_error(t2)
+        er2, ephi2, ez2, et2 = get_reco_interaction(r2, phi2, z2, t2, errmat_p_r, errmat_p_phi, errmat_p_z, errmat_p_t)
     else:
-        er2   = errmat_c_r.get_random_error(r2)
-        ephi2 = errmat_c_phi.get_random_error(phi2)
-        ez2   = errmat_c_z.get_random_error(z2)
-        et2   = errmat_c_t.get_random_error(t2)
+        er2, ephi2, ez2, et2 = get_reco_interaction(r2, phi2, z2, t2, errmat_c_r, errmat_c_phi, errmat_c_z, errmat_c_t)
+
 
     # Compute reconstructed quantities.
     r1_reco = r1 - er1

--- a/antea/mcsim/fastmc3d.py
+++ b/antea/mcsim/fastmc3d.py
@@ -15,11 +15,11 @@ from antea.mcsim.errmat3d import errmat3d
 import antea.reco.reco_functions as rf
 
 def get_reco_interaction(r: float, phi: float, z: float, t: float,
-                         errmat_r: errmat, errmat_ph: errmat, errmat_z: errmat, errmat_t: errmat):
+                         errmat_r: errmat, errmat_phi: errmat, errmat_z: errmat, errmat_t: errmat):
     """
     Extract the spatial coordinates and time for one interaction, using error matrices.
     """
-    reco_r   = errmatr.get_random_error(r)
+    reco_r   = errmat_r.get_random_error(r)
     reco_phi = errmat_phi.get_random_error(phi)
     reco_z   = errmat_z.get_random_error(z)
     reco_t   = errmat_t.get_random_error(t)

--- a/antea/mcsim/fastmc3d.py
+++ b/antea/mcsim/fastmc3d.py
@@ -14,6 +14,18 @@ from antea.mcsim.errmat   import errmat
 from antea.mcsim.errmat3d import errmat3d
 import antea.reco.reco_functions as rf
 
+def get_reco_interaction(r: float, phi: float, z: float, t: float,
+                         errmat_r: errmat, errmat_ph: errmati, errmat_z: errmat, errmat_t: errmat):
+    """
+    Extract the spatial coordinates and time for one interaction, using error matrices.
+    """
+    reco_r   = errmatr.get_random_error(r)
+    reco_phi = errmat_phi.get_random_error(phi)
+    reco_z   = errmat_z.get_random_error(z)
+    reco_t   = errmat_t.get_random_error(t)
+
+    return reco_r, reco_phi, reco_z, reco_t
+
 def simulate_reco_event(evt_id: int, hits: pd.DataFrame, particles: pd.DataFrame,
                         errmat_p_r: errmat, errmat_p_phi: errmat3d, errmat_p_z: errmat3d,
                         errmat_p_t: errmat, errmat_c_r: errmat, errmat_c_phi: errmat3d,
@@ -91,26 +103,14 @@ def simulate_reco_event(evt_id: int, hits: pd.DataFrame, particles: pd.DataFrame
 
     # Get all errors.
     if phot1:
-        er1   = errmat_p_r.get_random_error(r1)
-        ephi1 = errmat_p_phi.get_random_error(phi1, r1)
-        ez1   = errmat_p_z.get_random_error(z1, r1)
-        et1   = errmat_p_t.get_random_error(t1)
+        er1, ephi1, ez1, et1 = get_reco_interaction(r1, phi1, z1, t1, errmat_p_r, errmat_p_phi, errmat_p_z, errmat_p_t)
     else:
-        er1   = errmat_c_r.get_random_error(r1)
-        ephi1 = errmat_c_phi.get_random_error(phi1, r1)
-        ez1   = errmat_c_z.get_random_error(z1, r1)
-        et1   = errmat_c_t.get_random_error(t1)
+        er1, ephi1, ez1, et1 = get_reco_interaction(r1, phi1, z1, t1, errmat_c_r, errmat_c_phi, errmat_c_z, errmat_c_t)
 
     if phot2:
-        er2   = errmat_p_r.get_random_error(r2)
-        ephi2 = errmat_p_phi.get_random_error(phi2, r2)
-        ez2   = errmat_p_z.get_random_error(z2, r2)
-        et2   = errmat_p_t.get_random_error(t2)
+        er2, ephi2, ez2, et2 = get_reco_interaction(r2, phi2, z2, t2, errmat_p_r, errmat_p_phi, errmat_p_z, errmat_p_t)
     else:
-        er2   = errmat_c_r.get_random_error(r2)
-        ephi2 = errmat_c_phi.get_random_error(phi2, r2)
-        ez2   = errmat_c_z.get_random_error(z2, r2)
-        et2   = errmat_c_t.get_random_error(t2)
+        er2, ephi2, ez2, et2 = get_reco_interaction(r2, phi2, z2, t2, errmat_c_r, errmat_c_phi, errmat_c_z, errmat_c_t)
 
     if er1 == None or ephi1 == None or ez1 == None or et1 == None or er2 == None or ephi2 == None or ez2 == None or et2 == None:
         events = pd.DataFrame({'event_id':  [float(evt_id)],

--- a/antea/mcsim/fastmc3d.py
+++ b/antea/mcsim/fastmc3d.py
@@ -19,10 +19,10 @@ def get_reco_interaction(r: float, phi: float, z: float, t: float,
     """
     Extract the spatial coordinates and time for one interaction, using error matrices.
     """
-    reco_r   = errmat_r.get_random_error(r)
+    reco_r   = errmat_r  .get_random_error(r)
     reco_phi = errmat_phi.get_random_error(phi, r)
-    reco_z   = errmat_z.get_random_error(z, r)
-    reco_t   = errmat_t.get_random_error(t)
+    reco_z   = errmat_z  .get_random_error(z, r)
+    reco_t   = errmat_t  .get_random_error(t)
 
     return reco_r, reco_phi, reco_z, reco_t
 

--- a/antea/mcsim/fastmc3d.py
+++ b/antea/mcsim/fastmc3d.py
@@ -15,13 +15,13 @@ from antea.mcsim.errmat3d import errmat3d
 import antea.reco.reco_functions as rf
 
 def get_reco_interaction(r: float, phi: float, z: float, t: float,
-                         errmat_r: errmat, errmat_phi: errmat, errmat_z: errmat, errmat_t: errmat):
+                         errmat_r: errmat, errmat_phi: errmat3d, errmat_z: errmat3d, errmat_t: errmat):
     """
     Extract the spatial coordinates and time for one interaction, using error matrices.
     """
     reco_r   = errmat_r.get_random_error(r)
-    reco_phi = errmat_phi.get_random_error(phi)
-    reco_z   = errmat_z.get_random_error(z)
+    reco_phi = errmat_phi.get_random_error(phi, r)
+    reco_z   = errmat_z.get_random_error(z, r)
     reco_t   = errmat_t.get_random_error(t)
 
     return reco_r, reco_phi, reco_z, reco_t

--- a/antea/mcsim/fastmc3d.py
+++ b/antea/mcsim/fastmc3d.py
@@ -30,7 +30,8 @@ def simulate_reco_event(evt_id: int, hits: pd.DataFrame, particles: pd.DataFrame
                         errmat_p_r: errmat, errmat_p_phi: errmat3d, errmat_p_z: errmat3d,
                         errmat_p_t: errmat, errmat_c_r: errmat, errmat_c_phi: errmat3d,
                         errmat_c_z: errmat3d, errmat_c_t: errmat,
-                        true_e_threshold: float = 0., photo_range: float = 1.) -> pd.DataFrame:
+                        true_e_threshold: float = 0., photo_range: float = 1.,
+                        only_phot: bool = False) -> pd.DataFrame:
     """
     Simulate the reconstructed coordinates for 1 coincidence from true GEANT4 dataframes.
     """
@@ -64,7 +65,9 @@ def simulate_reco_event(evt_id: int, hits: pd.DataFrame, particles: pd.DataFrame
 
     pos1, pos2, t1, t2, phot1, phot2 = rf.find_first_interactions_in_active(evt_parts, evt_hits, photo_range)
 
-    if len(pos1) == 0 or len(pos2) == 0:
+    no_reco_positions = len(pos1) == 0 or len(pos2) == 0
+    no_phot_interactions = not phot1 or not phot2
+    if no_reco_positions or (only_phot and no_phot_interactions):
         events = pd.DataFrame({'event_id':  [float(evt_id)],
                                'true_energy': [energy],
                                'true_r1':   [0.],

--- a/antea/mcsim/fastmc3d.py
+++ b/antea/mcsim/fastmc3d.py
@@ -15,7 +15,7 @@ from antea.mcsim.errmat3d import errmat3d
 import antea.reco.reco_functions as rf
 
 def get_reco_interaction(r: float, phi: float, z: float, t: float,
-                         errmat_r: errmat, errmat_ph: errmati, errmat_z: errmat, errmat_t: errmat):
+                         errmat_r: errmat, errmat_ph: errmat, errmat_z: errmat, errmat_t: errmat):
     """
     Extract the spatial coordinates and time for one interaction, using error matrices.
     """


### PR DESCRIPTION
This PR adds the possibility of producing fast simulation coincidences only for events where both interactions are photoelectric-like. It allows one to save disk space for studies concerning photoelectric-like events.