### PR TITLE
Add fastmc script example

### DIFF
--- a/antea/scripts/fastmc.py
+++ b/antea/scripts/fastmc.py
@@ -1,0 +1,83 @@
+import sys
+import argparse
+import pandas   as pd
+
+import antea.database.load_db  as db
+import antea.mcsim   .errmat   as errmat
+import antea.mcsim   .errmat3d as errmat3d
+import antea.mcsim   .fastmc3d as fmc
+import antea.io      .mc_io    as mcio
+
+
+""" Example to run this script
+python fastmc.py 0 1 /input_path/ filesname /output_path/ /matrix_path/
+"""
+
+def parse_args(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('first_file' , type = int, help = "first file (inclusive)"    )
+    parser.add_argument('n_files'    , type = int, help = "number of files to analize")
+    parser.add_argument('input_path' ,             help = "input files path"          )
+    parser.add_argument('filename'   ,             help = "input files name"          )
+    parser.add_argument('output_path',             help = "output files path"         )
+    parser.add_argument('matrix_path',             help = "path of the error matrix"  )
+    return parser.parse_args()
+
+
+arguments     = parse_args(sys.argv)
+start         = arguments.first_file
+numb_of_files = arguments.n_files
+folder_in     = arguments.input_path
+filename      = arguments.filename
+folder_out    = arguments.output_path
+table_folder  = arguments.matrix_path
+
+
+err_r_phot_file    = table_folder + '/errmat_test_r_phot_like.npz'
+err_r_compt_file   = table_folder + '/errmat_test_r_compt_like.npz'
+err_phi_phot_file  = table_folder + '/errmat_test_phi_phot_like.npz'
+err_phi_compt_file = table_folder + '/errmat_test_phi_compt_like.npz'
+err_z_phot_file    = table_folder + '/errmat_test_z_phot_like.npz'
+err_z_compt_file   = table_folder + '/errmat_test_z_compt_like.npz'
+err_t_phot_file    = table_folder + '/errmat_test_t_phot_like.npz'
+err_t_compt_file   = table_folder + '/errmat_test_t_compt_like.npz'
+
+errmat_r_phot    = errmat  .errmat  (err_r_phot_file   )
+errmat_r_compt   = errmat  .errmat  (err_r_compt_file  )
+errmat_phi_phot  = errmat3d.errmat3d(err_phi_phot_file )
+errmat_phi_compt = errmat3d.errmat3d(err_phi_compt_file)
+errmat_z_phot    = errmat3d.errmat3d(err_z_phot_file   )
+errmat_z_compt   = errmat3d.errmat3d(err_z_compt_file  )
+errmat_t_phot    = errmat  .errmat  (err_t_phot_file   )
+errmat_t_compt   = errmat  .errmat  (err_t_compt_file  )
+
+energy_threshold = 0.98
+
+for file_number in range(start, start+numb_of_files):
+    sim_file = folder_in  + '/' + filename + f'.{file_number}.h5'
+    out_file = folder_out + '/' + filename + f'_reco_thr0pes.{file_number}.h5'
+
+    try:
+        particles = mcio.load_mcparticles(sim_file)
+    except:
+        print(f'File {sim_file} not found!')
+        continue
+    hits   = mcio.load_mchits(sim_file)
+    events = particles.event_id.unique()
+
+    reco = pd.DataFrame(columns=['event_id', 'true_energy',
+                                  'true_r1', 'true_phi1', 'true_z1', 'true_t1',
+                                  'true_r2', 'true_phi2', 'true_z2', 'true_t2',
+                                  'phot_like1', 'phot_like2',
+                                  'reco_r1', 'reco_phi1', 'reco_z1', 'reco_t1',
+                                  'reco_r2', 'reco_phi2', 'reco_z2', 'reco_t2'])
+    for evt in events:
+        evt_df = fmc.simulate_reco_event(evt, hits, particles, errmat_r_phot,
+                                         errmat_phi_phot,  errmat_z_phot,  errmat_t_phot,  errmat_r_compt,
+                                         errmat_phi_compt, errmat_z_compt, errmat_t_compt, energy_threshold,
+                                         energy_threshold, only_phot=False)
+        reco = pd.concat([reco, evt_df])
+
+    store = pd.HDFStore(out_file, "w", complib=str("zlib"), complevel=4)
+    store.put('reco', reco, format='table', data_columns=True)
+    store.close()

--- a/antea/scripts/fastmc.py
+++ b/antea/scripts/fastmc.py
@@ -75,7 +75,7 @@ for file_number in range(start, start+numb_of_files):
         evt_df = fmc.simulate_reco_event(evt, hits, particles, errmat_r_phot,
                                          errmat_phi_phot,  errmat_z_phot,  errmat_t_phot,  errmat_r_compt,
                                          errmat_phi_compt, errmat_z_compt, errmat_t_compt, energy_threshold,
-                                         energy_threshold, only_phot=False)
+                                         energy_threshold, photo_range=1., only_phot=False)
         reco = pd.concat([reco, evt_df])
 
     store = pd.HDFStore(out_file, "w", complib=str("zlib"), complevel=4)


### PR DESCRIPTION
A new script has been added related to the fastmc to show how the `simulate_reco_event` function works and needs to be called.