### PR TITLE
Update of coincidence code

### DIFF
--- a/antea/scripts/reconstruct_coincidences.py
+++ b/antea/scripts/reconstruct_coincidences.py
@@ -72,7 +72,6 @@ true_time1, true_time2               = [], []
 touched_sipms1, touched_sipms2       = [], []
 photo1, photo2                  = [], []
 max_hit_distance1, max_hit_distance2 = [], []
-hit_energy1, hit_energy2             = [], []
 
 event_ids = []
 
@@ -250,9 +249,6 @@ for ifile in range(start, start+numb):
         distances2 = rf.find_hit_distances_from_true_pos(evt_hits, true_pos2)
         max_dist2  = distances2.max()
 
-        tot_hit_energy1 = hits1.energy.sum()
-        tot_hit_energy2 = hits2.energy.sum()
-
         event_ids.append(evt)
         reco_r1.append(r1)
         reco_phi1.append(phi1)
@@ -265,7 +261,6 @@ for ifile in range(start, start+numb):
         true_time1.append(true_t1/units.ps)
         photo1.append(phot1)
         max_hit_distance1.append(max_dist1)
-        hit_energy1.append(tot_hit_energy1)
         reco_r2.append(r2)
         reco_phi2.append(phi2)
         reco_z2.append(z2)
@@ -277,7 +272,6 @@ for ifile in range(start, start+numb):
         true_time2.append(true_t2/units.ps)
         photo2.append(phot2)
         max_hit_distance2.append(max_dist2)
-        hit_energy2.append(tot_hit_energy2)
 
 
 a_true_r1   = np.array(true_r1)
@@ -299,7 +293,6 @@ a_first_time1_4 = np.array(first_time1[3])
 a_true_time1  = np.array(true_time1)
 a_photo1    = np.array(photo1)
 a_max_hit_distance1 = np.array(max_hit_distance1)
-a_hit_energy1 = np.array(hit_energy1)
 
 a_true_r2   = np.array(true_r2)
 a_true_phi2 = np.array(true_phi2)
@@ -320,7 +313,6 @@ a_first_time2_4 = np.array(first_time2[3])
 a_true_time2  = np.array(true_time2)
 a_photo2    = np.array(photo2)
 a_max_hit_distance2 = np.array(max_hit_distance2)
-a_hit_energy2 = np.array(hit_energy2)
 
 a_event_ids = np.array(event_ids)
 
@@ -342,7 +334,7 @@ np.savez(evt_file,
          a_true_time1=a_true_time1, a_true_time2=a_true_time2,
          a_photo1=a_photo1, a_photo2=a_photo2,
          a_max_hit_distance1=a_max_hit_distance1, a_max_hit_distance2=a_max_hit_distance2,
-         a_hit_energy1=a_hit_energy1, a_hit_energy2=a_hit_energy2, a_event_ids=a_event_ids)
+         a_event_ids=a_event_ids)
 
 print('Not a coincidence: {}'.format(c0))
 print('Not passing threshold r = {}, phi = {}, z = {}, E = {}'.format(c1, c2, c3, c4))

--- a/antea/scripts/reconstruct_coincidences.py
+++ b/antea/scripts/reconstruct_coincidences.py
@@ -68,11 +68,11 @@ first_sipm1 = [[] for i in range(0, len(timestamp_thr))]
 first_sipm2 = [[] for i in range(0, len(timestamp_thr))]
 first_time1 = [[] for i in range(0, len(timestamp_thr))]
 first_time2 = [[] for i in range(0, len(timestamp_thr))]
-true_time1, true_time2          = [], []
-touched_sipms1, touched_sipms2  = [], []
-photo1, photo_like1             = [], []
-photo2, photo_like2             = [], []
-hit_energy1, hit_energy2        = [], []
+true_time1, true_time2               = [], []
+touched_sipms1, touched_sipms2       = [], []
+photo1, photo_like1                  = [], []
+max_hit_distance1, max_hit_distance2 = [], []
+hit_energy1, hit_energy2             = [], []
 
 event_ids = []
 
@@ -246,17 +246,9 @@ for ifile in range(start, start+numb):
 
         ## extract information about the interaction being photoelectric-like
         distances1 = rf.find_hit_distances_from_true_pos(evt_hits, true_pos1)
-        if len(distances1[distances1 > 1.]): ## hits at <1 mm distance are considered of the same point
-            phot_like1 = False
-        else:
-            phot_like1 = True
-
+        max_dist1  = distances1.max()
         distances2 = rf.find_hit_distances_from_true_pos(evt_hits, true_pos2)
-
-        if len(distances2[distances2 > 1.]):
-            phot_like2 = False
-        else:
-            phot_like2 = True
+        max_dist2  = distances2.max()
 
         tot_hit_energy1 = hits1.energy.sum()
         tot_hit_energy2 = hits2.energy.sum()
@@ -272,7 +264,7 @@ for ifile in range(start, start+numb):
         touched_sipms1.append(len(q1e))
         true_time1.append(true_t1/units.ps)
         photo1.append(phot1)
-        photo_like1.append(phot_like1)
+        max_hit_distance1.append(max_dist1)
         hit_energy1.append(tot_hit_energy1)
         reco_r2.append(r2)
         reco_phi2.append(phi2)
@@ -284,7 +276,7 @@ for ifile in range(start, start+numb):
         touched_sipms2.append(len(q2e))
         true_time2.append(true_t2/units.ps)
         photo2.append(phot2)
-        photo_like2.append(phot_like2)
+        max_hit_distance2.append(max_dist2)
         hit_energy2.append(tot_hit_energy2)
 
 
@@ -306,7 +298,7 @@ a_first_sipm1_4 = np.array(first_sipm1[3])
 a_first_time1_4 = np.array(first_time1[3])
 a_true_time1  = np.array(true_time1)
 a_photo1    = np.array(photo1)
-a_photo_like1    = np.array(photo_like1)
+a_max_hit_distance1 = np.array(max_hit_distance1)
 a_hit_energy1 = np.array(hit_energy1)
 
 a_true_r2   = np.array(true_r2)
@@ -327,7 +319,7 @@ a_first_sipm2_4 = np.array(first_sipm2[3])
 a_first_time2_4 = np.array(first_time2[3])
 a_true_time2  = np.array(true_time2)
 a_photo2    = np.array(photo2)
-a_photo_like2    = np.array(photo_like2)
+a_max_hit_distance2 = np.array(max_hit_distance2)
 a_hit_energy2 = np.array(hit_energy2)
 
 a_event_ids = np.array(event_ids)
@@ -349,7 +341,7 @@ np.savez(evt_file,
          a_first_sipm2_4=a_first_sipm2_4, a_first_time2_4=a_first_time2_4,
          a_true_time1=a_true_time1, a_true_time2=a_true_time2,
          a_photo1=a_photo1, a_photo2=a_photo2,
-         a_photo_like1=a_photo_like1, a_photo_like2=a_photo_like2,
+         a_max_hit_distance1=a_max_hit_distance1, a_max_hit_distance2=a_max_hit_distance2,
          a_hit_energy1=a_hit_energy1, a_hit_energy2=a_hit_energy2, a_event_ids=a_event_ids)
 
 print('Not a coincidence: {}'.format(c0))

--- a/antea/scripts/reconstruct_coincidences.py
+++ b/antea/scripts/reconstruct_coincidences.py
@@ -70,7 +70,7 @@ first_time1 = [[] for i in range(0, len(timestamp_thr))]
 first_time2 = [[] for i in range(0, len(timestamp_thr))]
 true_time1, true_time2               = [], []
 touched_sipms1, touched_sipms2       = [], []
-photo1, photo_like1                  = [], []
+photo1, photo2                  = [], []
 max_hit_distance1, max_hit_distance2 = [], []
 hit_energy1, hit_energy2             = [], []
 

--- a/antea/scripts/reconstruct_coincidences.py
+++ b/antea/scripts/reconstruct_coincidences.py
@@ -245,19 +245,13 @@ for ifile in range(start, start+numb):
                     phot1 = True
 
         ## extract information about the interaction being photoelectric-like
-        positions         = np.array([evt_hits.x, evt_hits.y, evt_hits.z]).transpose()
-        scalar_products1 = positions.dot(true_pos1)
-        hits1 = evt_hits[scalar_products1 >= 0]
-        pos_hits1  = np.array([hits1.x, hits1.y, hits1.z]).transpose()
-        distances1 = np.linalg.norm(np.subtract(pos_hits1, true_pos1), axis=1)
+        distances1 = rf.find_hit_distances_from_true_pos(evt_hits, true_pos1)
         if len(distances1[distances1 > 1.]): ## hits at <1 mm distance are considered of the same point
             phot_like1 = False
         else:
             phot_like1 = True
 
-        hits2 = evt_hits[scalar_products1 < 0]
-        pos_hits2  = np.array([hits2.x, hits2.y, hits2.z]).transpose()
-        distances2 = np.linalg.norm(np.subtract(pos_hits2, true_pos2), axis=1)
+        distances2 = rf.find_hit_distances_from_true_pos(evt_hits, true_pos2)
 
         if len(distances2[distances2 > 1.]):
             phot_like2 = False


### PR DESCRIPTION
This PR updates the script to reconstruct coincidences to save the maximum distance among hits of the same interactions, instead of defining the distance threshold for an interaction to be photoelectric-like. This way, the choice of the threshold can be done in the analysis.
It also uses ANTEA functions instead of rewriting the code.