### PR TITLE
Use an average of the first n photoelectrons to calculate the time of the interaction

### DIFF
--- a/antea/elec/tof_functions.py
+++ b/antea/elec/tof_functions.py
@@ -58,8 +58,8 @@ def tdc_convolution(tof_response: pd.DataFrame,
     """
     pe_vect = np.zeros(time_window)
     sel_tof = tof_response[(tof_response.sensor_id == s_id) &
-                           (tof_response.time_bin < time_window)]
-    pe_vect[sel_tof.time_bin.values] = sel_tof.charge.values
+                           (tof_response.time < time_window)]
+    pe_vect[sel_tof.time.values] = sel_tof.charge.values
     tdc_conv = convolve_tof(spe_response, pe_vect)
     return tdc_conv
 
@@ -70,7 +70,7 @@ def translate_charge_conv_to_wf_df(event_id: int,
     """
     Translates a given numpy array into a tof type dataframe.
     """
-    keys        = np.array(['event_id', 'sensor_id', 'time_bin', 'charge'])
+    keys        = np.array(['event_id', 'sensor_id', 'time', 'charge'])
     t_bin       = np.where(conv_vect>0)[0]
     charge      = conv_vect[conv_vect>0]
     evt         = np.full(len(t_bin), event_id)
@@ -78,5 +78,5 @@ def translate_charge_conv_to_wf_df(event_id: int,
     a_wf        = np.array([evt, sns_id_full, t_bin, charge])
     wf_df       = pd.DataFrame(a_wf.T, columns=keys).astype({'event_id': 'int32',
                                                             'sensor_id': 'int32',
-                                                            'time_bin' : 'int32'})
+                                                            'time'     : 'int32'})
     return wf_df

--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -185,7 +185,8 @@ def part_first_hit(hits: pd.DataFrame,
 
 
 def find_first_time_of_sensors(tof_response: pd.DataFrame,
-                               sns_ids: Sequence[int])-> Tuple[int, int]:
+                               sns_ids: Sequence[int],
+                               n_pe: int = 1)-> Tuple[Sequence[int], float]:
     """
     This function looks for the time among all sensors for the first
     photoelectron detected.
@@ -198,13 +199,13 @@ def find_first_time_of_sensors(tof_response: pd.DataFrame,
     if tof.empty:
         raise WaveformEmptyTable("Tof dataframe is empty")
 
-    min_t  = tof.time_bin.min()
-    min_df = tof[tof.time_bin == min_t]
-
-    if len(min_df)>1:
-        min_id = min_df[min_df.sensor_id == min_df.sensor_id.min()].sensor_id.values[0]
+    if n_pe == 1:
+        min_t  = tof.time.min()
+        min_df = tof[tof.time == min_t]
     else:
-        min_id = min_df.sensor_id.values[0]
+        first_times = tof.sort_values(by=['time']).iloc[0:n_pe]
+        min_t       = first_times.time.mean()
+        min_ids     = first_times.sensor_id.values
 
     return np.abs(min_id), min_t
 
@@ -360,12 +361,13 @@ def reconstruct_coincidences(sns_response: pd.DataFrame,
 
 def find_coincidence_timestamps(tof_response: pd.DataFrame,
                                 sns1: Sequence[int],
-                                sns2: Sequence[int])-> Tuple[int, int, int, int]:
+                                sns2: Sequence[int],
+                                int: n_pe)-> Tuple[Tuple[int], Tuple[int], float, float]:
     """
-    Finds the first time and sensor of each one of two sets of sensors,
-    given a sensor response dataframe.
+    Finds the first time and the IDs of the sensors used to calculate it
+    for each one of two sets of sensors, given a sensor response dataframe.
     """
-    min1, time1 = find_first_time_of_sensors(tof_response, -sns1)
-    min2, time2 = find_first_time_of_sensors(tof_response, -sns2)
+    min1, time1 = find_first_time_of_sensors(tof_response, -sns1, n_pe)
+    min2, time2 = find_first_time_of_sensors(tof_response, -sns2, n_pe)
 
     return min1, min2, time1, time2

--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -200,14 +200,15 @@ def find_first_time_of_sensors(tof_response: pd.DataFrame,
         raise WaveformEmptyTable("Tof dataframe is empty")
 
     if n_pe == 1:
-        min_t  = tof.time.min()
-        min_df = tof[tof.time == min_t]
+        min_t   = tof.time.min()
+        min_df  = tof[tof.time == min_t]
+        min_ids = min_df.sensor_id.values
     else:
         first_times = tof.sort_values(by=['time']).iloc[0:n_pe]
         min_t       = first_times.time.mean()
         min_ids     = first_times.sensor_id.values
 
-    return np.abs(min_id), min_t
+    return np.abs(min_ids), min_t
 
 
 def find_hit_distances_from_true_pos(hits: pd.DataFrame,
@@ -362,7 +363,7 @@ def reconstruct_coincidences(sns_response: pd.DataFrame,
 def find_coincidence_timestamps(tof_response: pd.DataFrame,
                                 sns1: Sequence[int],
                                 sns2: Sequence[int],
-                                int: n_pe)-> Tuple[Tuple[int], Tuple[int], float, float]:
+                                n_pe: int)-> Tuple[Tuple[int], Tuple[int], float, float]:
     """
     Finds the first time and the IDs of the sensors used to calculate it
     for each one of two sets of sensors, given a sensor response dataframe.

--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -363,7 +363,7 @@ def reconstruct_coincidences(sns_response: pd.DataFrame,
 def find_coincidence_timestamps(tof_response: pd.DataFrame,
                                 sns1: Sequence[int],
                                 sns2: Sequence[int],
-                                n_pe: int)-> Tuple[Tuple[int], Tuple[int], float, float]:
+                                n_pe: int = 1)-> Tuple[Tuple[int], Tuple[int], float, float]:
     """
     Finds the first time and the IDs of the sensors used to calculate it
     for each one of two sets of sensors, given a sensor response dataframe.

--- a/antea/reco/reco_functions_test.py
+++ b/antea/reco/reco_functions_test.py
@@ -304,7 +304,7 @@ def test_find_first_time_of_sensors_average_and_jitter(ANTEADATADIR, n_pe):
         times   = tof.time_bin.values
         ids, min_time  = rf.find_first_time_of_sensors(tof, sns_ids, n_pe)
 
-        assert len(ids) == n_pe
+        assert len(ids) <= n_pe
 
         rest_of_ids   = [x for x in sns_ids if x not in -ids]
         rest_of_times = tof[tof.sensor_id.isin(rest_of_ids)].time.values

--- a/antea/scripts/reconstruct_coincidences.py
+++ b/antea/scripts/reconstruct_coincidences.py
@@ -193,18 +193,19 @@ for ifile in range(start, start+numb):
 
         try:
             min_id1, min_id2, min_t1, min_t2 = rf.find_coincidence_timestamps(evt_tof_exp_dist, sns1, sns2, n_pe)
+            ave_pos1 = calculate_average_SiPM_first_pos(min_id1)
+            ave_pos2 = calculate_average_SiPM_first_pos(min_id2)
+            first_sipm1.append(ave_pos1)
+            first_sipm2.append(ave_pos1)
         except:
             print(f'TOF dataframe has no minimum time for event {evt}')
-            min_id1, min_id2, min_t1, min_t2 = -1, -1, -1, -1
+            _, _, min_t1, min_t2 = [-1], [-1], -1, -1
+            first_sipm1.append(np.array([0, 0, 0]))
+            first_sipm2.append(np.array([0, 0, 0]))
 
-        ave_pos1 = calculate_average_SiPM_first_pos(min_id1)
-        ave_pos2 = calculate_average_SiPM_first_pos(min_id2)
 
-        first_sipm1.append(ave_pos1)
-        first_time1.append(min_t1*tof_bin_size/units.ps)
-
-        first_sipm2.append(ave_pos1)
-        first_time2.append(min_t2*tof_bin_size/units.ps)
+        first_time1.append(min_t1)
+        first_time2.append(min_t2)
 
 
         ## extract information about the interaction being photoelectric

--- a/antea/scripts/reconstruct_coincidences.py
+++ b/antea/scripts/reconstruct_coincidences.py
@@ -62,7 +62,7 @@ def reconstruct_position(q, pos, thr_r, thr_phi, thr_z):
 
     return r, phi, z
 
-def calculate_average_SiPM_first_pos(min_ids):
+def calculate_average_SiPM_pos(min_ids):
     sipm     = DataSiPM_idx.loc[np.abs(min_ids)]
     sipm_pos = np.array([sipm.X.values, sipm.Y.values, sipm.Z.values]).transpose()
     ave_pos  = np.average(sipm_pos, axis=0)
@@ -197,7 +197,7 @@ for ifile in range(start, start+numb):
             ave_pos2 = calculate_average_SiPM_first_pos(min_id2)
             first_sipm1.append(ave_pos1)
             first_sipm2.append(ave_pos2)
-        except:
+        except WaveformEmptyTable:
             print(f'TOF dataframe has no minimum time for event {evt}')
             _, _, min_t1, min_t2 = [-1], [-1], -1, -1
             first_sipm1.append(np.array([0, 0, 0]))

--- a/antea/scripts/reconstruct_coincidences.py
+++ b/antea/scripts/reconstruct_coincidences.py
@@ -196,7 +196,7 @@ for ifile in range(start, start+numb):
             ave_pos1 = calculate_average_SiPM_first_pos(min_id1)
             ave_pos2 = calculate_average_SiPM_first_pos(min_id2)
             first_sipm1.append(ave_pos1)
-            first_sipm2.append(ave_pos1)
+            first_sipm2.append(ave_pos2)
         except:
             print(f'TOF dataframe has no minimum time for event {evt}')
             _, _, min_t1, min_t2 = [-1], [-1], -1, -1


### PR DESCRIPTION
This PR adds the possibility of using the first N photoelectrons to calculate the time of the interaction. If N == 1, a simplified code is used, to avoid time-consuming sorting. The script used to reconstruct the coincidences is also updated.