### PR TITLE
Include the 4-tiles case in coinc plane

### DIFF
--- a/antea/reco/petit_reco_functions.py
+++ b/antea/reco/petit_reco_functions.py
@@ -33,13 +33,15 @@ def compute_coincidences(df: pd.DataFrame,
     return df_coinc
 
 
-central_sns_det   = [ 44,  45,  54,  55]
-central_sns_coinc = [122, 123, 132, 133]
+central_sns_det          = [ 44,  45,  54,  55]
+central_sns_coinc_1tile  = [122, 123, 132, 133]
+central_sns_coinc_4tiles = [144, 145, 154, 155]
 
 def is_max_charge_at_center(df: pd.DataFrame,
-                            det_plane: bool = True,
-                            variable:   str = 'charge',
-                            tot_mode:  bool = False) -> bool:
+                            det_plane:          bool = True,
+                            coinc_plane_1_tile: bool = True,
+                            variable:            str = 'charge',
+                            tot_mode:           bool = False) -> bool:
     """
     Returns True if the maximum charge of the event has been detected
     in one of the four central sensors of the desired plane.
@@ -49,7 +51,10 @@ def is_max_charge_at_center(df: pd.DataFrame,
         central_sns = central_sns_det
     else:
         tofpet_id   = 2
-        central_sns = central_sns_coinc
+        if coinc_plane_1_tile:
+            central_sns = central_sns_coinc_1tile
+        else:
+            central_sns = central_sns_coinc_4tiles
 
     df = df[df.tofpet_id == tofpet_id]
     if len(df)==0:
@@ -66,6 +71,7 @@ def is_max_charge_at_center(df: pd.DataFrame,
 def select_evts_with_max_charge_at_center(df: pd.DataFrame,
                                           evt_groupby: Sequence[str] = ['event_id'],
                                           det_plane:            bool = True,
+                                          coinc_plane_1_tile:   bool = True,
                                           variable:              str = 'charge',
                                           tot_mode:             bool = False) -> pd.DataFrame:
     """
@@ -74,10 +80,11 @@ def select_evts_with_max_charge_at_center(df: pd.DataFrame,
     should be `charge` and `tot_mode` False.
     """
     df_filter_center = df.groupby(evt_groupby).filter(is_max_charge_at_center,
-                                                      dropna    = True,
-                                                      det_plane = det_plane,
-                                                      variable  = variable,
-                                                      tot_mode  = tot_mode)
+                                                      dropna             = True,
+                                                      det_plane          = det_plane,
+                                                      coinc_plane_1_tile = coinc_plane_1_tile,
+                                                      variable           = variable,
+                                                      tot_mode           = tot_mode)
     return df_filter_center
 
 

--- a/antea/reco/petit_reco_functions_test.py
+++ b/antea/reco/petit_reco_functions_test.py
@@ -32,16 +32,16 @@ def test_compute_coincidences(ANTEADATADIR, filename, data):
     assert np.all(s_d) and np.all(s_c)
 
 
-@mark.parametrize("filename data det_plane variable tot_mode".split(),
-                  (('petit_mc_test.pet.h5', False,  True,          'charge', False),
-                   ('petit_mc_test.pet.h5', False, False,          'charge', False),
-                   ('petit_data_test.h5',    True,  True, 'efine_corrected', False),
-                   ('petit_data_test.h5',    True, False, 'efine_corrected', False),
-                   ('petit_data_test.h5',    True,  True,          'intg_w', False),
-                   ('petit_data_test.h5',    True,  True,      'intg_w_ToT',  True),
-                   ('petit_data_test.h5',    True, False,      'intg_w_ToT',  True)))
-def test_select_evts_with_max_charge_at_center(ANTEADATADIR, filename, data,
-                                               det_plane, variable, tot_mode):
+@mark.parametrize("filename data det_plane coinc_plane_1_tile variable tot_mode".split(),
+                  (('petit_mc_test.pet.h5', False, True,  True,          'charge', False),
+                   ('petit_mc_test.pet.h5', False, True, False,          'charge', False),
+                   ('petit_data_test.h5',    True, True,  True, 'efine_corrected', False),
+                   ('petit_data_test.h5',    True, True, False, 'efine_corrected', False),
+                   ('petit_data_test.h5',    True, True,  True,          'intg_w', False),
+                   ('petit_data_test.h5',    True, True,  True,      'intg_w_ToT',  True),
+                   ('petit_data_test.h5',    True, True, False,      'intg_w_ToT',  True)))
+def test_select_evts_with_max_charge_at_center(ANTEADATADIR, filename, data, det_plane,
+                                               coinc_plane_1_tile, variable, tot_mode):
     """
     Checks that the max charge (in terms of the desired variable) is at center
     of the chosen plane.
@@ -61,13 +61,17 @@ def test_select_evts_with_max_charge_at_center(ANTEADATADIR, filename, data,
         central_sns = prf.central_sns_det
     else:
         tofpet_id   = 2
-        central_sns = prf.central_sns_coinc
+        if coinc_plane_1_tile:
+            central_sns = prf.central_sns_coinc_1tile
+        else:
+            central_sns = prf.central_sns_coinc_4tiles
 
     df_center = prf.select_evts_with_max_charge_at_center(df,
-                                                          evt_groupby = evt_groupby,
-                                                          det_plane   = det_plane,
-                                                          variable    = variable,
-                                                          tot_mode    = tot_mode)
+                                                          evt_groupby        = evt_groupby,
+                                                          det_plane          = det_plane,
+                                                          coinc_plane_1_tile = coinc_plane_1_tile,
+                                                          variable           = variable,
+                                                          tot_mode           = tot_mode)
     df_center = df_center[df_center.tofpet_id==tofpet_id]
     assert len(df_center) > 0
 


### PR DESCRIPTION
In `petit_reco_functions` were not included the central sensor ids for the case of 4 tiles in the Coincidence plane. This PR fixes it by adding a new boolean parameter.