### PR TITLE
Add case of 4 tiles in the coincidence plane

### DIFF
--- a/antea/reco/petit_reco_functions.py
+++ b/antea/reco/petit_reco_functions.py
@@ -33,13 +33,15 @@ def compute_coincidences(df: pd.DataFrame,
     return df_coinc
 
 
-central_sns_det   = [ 44,  45,  54,  55]
-central_sns_coinc = [122, 123, 132, 133]
+central_sns_det          = [ 44,  45,  54,  55]
+central_sns_coinc_1tile  = [122, 123, 132, 133]
+central_sns_coinc_4tiles = [144, 145, 154, 155]
 
 def is_max_charge_at_center(df: pd.DataFrame,
-                            det_plane: bool = True,
-                            variable:   str = 'charge',
-                            tot_mode:  bool = False) -> bool:
+                            det_plane:          bool = True,
+                            coinc_plane_1_tile: bool = True,
+                            variable:            str = 'charge',
+                            tot_mode:           bool = False) -> bool:
     """
     Returns True if the maximum charge of the event has been detected
     in one of the four central sensors of the desired plane.
@@ -49,7 +51,10 @@ def is_max_charge_at_center(df: pd.DataFrame,
         central_sns = central_sns_det
     else:
         tofpet_id   = 2
-        central_sns = central_sns_coinc
+        if coinc_plane_1_tile:
+            central_sns = central_sns_coinc_1tile
+        else:
+            central_sns = central_sns_coinc_4tiles
 
     df = df[df.tofpet_id == tofpet_id]
     if len(df)==0:
@@ -66,6 +71,7 @@ def is_max_charge_at_center(df: pd.DataFrame,
 def select_evts_with_max_charge_at_center(df: pd.DataFrame,
                                           evt_groupby: Sequence[str] = ['event_id'],
                                           det_plane:            bool = True,
+                                          coinc_plane_1_tile:   bool = True,
                                           variable:              str = 'charge',
                                           tot_mode:             bool = False) -> pd.DataFrame:
     """
@@ -74,10 +80,11 @@ def select_evts_with_max_charge_at_center(df: pd.DataFrame,
     should be `charge` and `tot_mode` False.
     """
     df_filter_center = df.groupby(evt_groupby).filter(is_max_charge_at_center,
-                                                      dropna    = True,
-                                                      det_plane = det_plane,
-                                                      variable  = variable,
-                                                      tot_mode  = tot_mode)
+                                                      dropna             = True,
+                                                      det_plane          = det_plane,
+                                                      coinc_plane_1_tile = coinc_plane_1_tile,
+                                                      variable           = variable,
+                                                      tot_mode           = tot_mode)
     return df_filter_center
 
 

--- a/antea/reco/petit_reco_functions.py
+++ b/antea/reco/petit_reco_functions.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy  as np
 
-from typing import Sequence
+from typing import Sequence, Tuple
 
 
 def tofpetid(sid: int) -> int:
@@ -33,28 +33,42 @@ def compute_coincidences(df: pd.DataFrame,
     return df_coinc
 
 
-central_sns_det          = [ 44,  45,  54,  55]
-central_sns_coinc_1tile  = [122, 123, 132, 133]
-central_sns_coinc_4tiles = [144, 145, 154, 155]
+def sensor_params(det_plane:          bool = True,
+                  coinc_plane_4tiles: bool = False) -> Tuple[int, Sequence[int], Sequence[int], Sequence[int]]:
+    """
+    Returns the corresponding ids of tofpet_id, central_sns, int_area and corona
+    of the desired plane.
+    """
+    tofpet_id   = 0
+    central_sns = np.array([ 44,  45,  54,  55])
+    int_area    = np.array([22, 23, 24, 25, 26, 27, 32, 33, 34, 35, 36, 37, 42, 43, 44, 45, 46, 47,
+                            52, 53, 54, 55, 56, 57, 62, 63, 64, 65, 66, 67, 72, 73, 74, 75, 76, 77])
+    corona      = np.array([11, 12, 13, 14, 15, 16, 17, 18, 21, 28, 31, 38, 41, 48,
+                            51, 58, 61, 68, 71, 78, 81, 82, 83, 84, 85, 86, 87, 88])
+    if not det_plane:
+        tofpet_id = 2
+        if coinc_plane_4tiles:
+            central_sns = central_sns + 100
+            int_area    = int_area    + 100
+            corona      = corona      + 100
+        else:
+            central_sns = np.array([122, 123, 132, 133])
+            int_area    = central_sns
+            corona      = np.array([111, 112, 113, 114, 121, 124, 131, 134, 141, 142, 143, 144])
+
+    return tofpet_id, central_sns, int_area, corona
+
 
 def is_max_charge_at_center(df: pd.DataFrame,
                             det_plane:          bool = True,
-                            coinc_plane_1_tile: bool = True,
+                            coinc_plane_4tiles: bool = False,
                             variable:            str = 'charge',
                             tot_mode:           bool = False) -> bool:
     """
     Returns True if the maximum charge of the event has been detected
     in one of the four central sensors of the desired plane.
     """
-    if det_plane:
-        tofpet_id   = 0
-        central_sns = central_sns_det
-    else:
-        tofpet_id   = 2
-        if coinc_plane_1_tile:
-            central_sns = central_sns_coinc_1tile
-        else:
-            central_sns = central_sns_coinc_4tiles
+    tofpet_id, central_sns, _, _ = sensor_params(det_plane, coinc_plane_4tiles)
 
     df = df[df.tofpet_id == tofpet_id]
     if len(df)==0:
@@ -71,7 +85,7 @@ def is_max_charge_at_center(df: pd.DataFrame,
 def select_evts_with_max_charge_at_center(df: pd.DataFrame,
                                           evt_groupby: Sequence[str] = ['event_id'],
                                           det_plane:            bool = True,
-                                          coinc_plane_1_tile:   bool = True,
+                                          coinc_plane_4tiles:   bool = False,
                                           variable:              str = 'charge',
                                           tot_mode:             bool = False) -> pd.DataFrame:
     """
@@ -82,24 +96,22 @@ def select_evts_with_max_charge_at_center(df: pd.DataFrame,
     df_filter_center = df.groupby(evt_groupby).filter(is_max_charge_at_center,
                                                       dropna             = True,
                                                       det_plane          = det_plane,
-                                                      coinc_plane_1_tile = coinc_plane_1_tile,
+                                                      coinc_plane_4tiles = coinc_plane_4tiles,
                                                       variable           = variable,
                                                       tot_mode           = tot_mode)
     return df_filter_center
 
 
-int_area = [22, 23, 24, 25, 26, 27, 32, 33, 34, 35, 36, 37, 42, 43, 44, 45, 46, 47,
-            52, 53, 54, 55, 56, 57, 62, 63, 64, 65, 66, 67, 72, 73, 74, 75, 76, 77]
-
-corona   = [11, 12, 13, 14, 15, 16, 17, 18, 21, 28, 31, 38, 41, 48,
-            51, 58, 61, 68, 71, 78, 81, 82, 83, 84, 85, 86, 87, 88]
-
-def is_event_contained_in_det_plane(df: pd.DataFrame) -> bool:
+def is_event_contained(df: pd.DataFrame,
+                       det_plane:          bool = True,
+                       coinc_plane_4tiles: bool = False) -> bool:
     """
     Returns True if all the sensors of the event are located within
-    the internal area of the detection plane.
+    the internal area of the desired plane.
     """
-    df          = df[df.tofpet_id == 0] ## Detection plane
+    tofpet_id, _, int_area, _ = sensor_params(det_plane, coinc_plane_4tiles)
+
+    df          = df[df.tofpet_id == tofpet_id]
     sens_unique = df.sensor_id.unique()
     if len(sens_unique):
         return set(sens_unique).issubset(set(int_area))
@@ -107,23 +119,32 @@ def is_event_contained_in_det_plane(df: pd.DataFrame) -> bool:
         return False
 
 
-def select_contained_evts_in_det_plane(df: pd.DataFrame,
-                                       evt_groupby: Sequence[str] = ['event_id']) -> pd.DataFrame:
+def select_contained_evts(df: pd.DataFrame,
+                          evt_groupby: Sequence[str] = ['event_id'],
+                          det_plane:            bool = True,
+                          coinc_plane_4tiles:   bool = False) -> pd.DataFrame:
     """
     Returns a dataframe with only the events with touched sensors
-    located within the internal area of the detection plane.
+    located within the internal area of the desired plane.
     """
-    df_cov_evts = df.groupby(evt_groupby).filter(is_event_contained_in_det_plane)
+    df_cov_evts = df.groupby(evt_groupby).filter(is_event_contained,
+                                                 dropna             = True,
+                                                 det_plane          = det_plane,
+                                                 coinc_plane_4tiles = coinc_plane_4tiles)
     return df_cov_evts
 
 
 def compute_charge_ratio_in_corona(df: pd.DataFrame,
                                    evt_groupby: Sequence[str] = ['event_id'],
-                                   variable: str = 'charge') -> pd.Series:
+                                   variable:              str = 'charge',
+                                   det_plane:            bool = True,
+                                   coinc_plane_4tiles:   bool = False) -> pd.Series:
     """
-    Computes the ratio of charge detected in the external corona of the detection
+    Computes the ratio of charge detected in the external corona of the desired
     plane with respect to the total charge of that plane.
     """
-    tot_ch_d = df[df.tofpet_id==0]          .groupby(evt_groupby)[variable].sum()
+    tofpet_id, _, _, corona =  sensor_params(det_plane, coinc_plane_4tiles)
+
+    tot_ch_d = df[df.tofpet_id==tofpet_id]  .groupby(evt_groupby)[variable].sum()
     cor_ch   = df[df.sensor_id.isin(corona)].groupby(evt_groupby)[variable].sum()
     return (cor_ch/tot_ch_d).fillna(0)

--- a/antea/reco/petit_reco_functions_test.py
+++ b/antea/reco/petit_reco_functions_test.py
@@ -73,12 +73,16 @@ def test_select_evts_with_max_charge_at_center(ANTEADATADIR, filename, data, det
         assert sns_max in central_sns
 
 
-@mark.parametrize("filename data variable".split(),
-                  (('petit_mc_test.pet.h5', False,          'charge'),
-                   ('petit_data_test.h5',    True, 'efine_corrected'),
-                   ('petit_data_test.h5',    True,          'intg_w'),
-                   ('petit_data_test.h5',    True,      'intg_w_ToT')))
-def test_contained_evts_in_det_plane_and_compute_ratio_in_corona(ANTEADATADIR, filename, data, variable):
+@mark.parametrize("filename data det_plane variable".split(),
+                  (('petit_mc_test.pet.h5', False, True,          'charge'),
+                   ('petit_data_test.h5',    True, True, 'efine_corrected'),
+                   ('petit_data_test.h5',    True, True,          'intg_w'),
+                   ('petit_data_test.h5',    True, True,      'intg_w_ToT'),
+                   ('petit_mc_test.pet.h5', False, False,          'charge'),
+                   ('petit_data_test.h5',    True, False, 'efine_corrected'),
+                   ('petit_data_test.h5',    True, False,          'intg_w'),
+                   ('petit_data_test.h5',    True, False,      'intg_w_ToT')))
+def test_contained_evts_and_compute_ratio_in_corona(ANTEADATADIR, filename, det_plane, data, variable):
     """
     Checks whether the event is fully contained in the detection plane and
     checks that the ratio of charge in the external corona is correct.
@@ -93,13 +97,13 @@ def test_contained_evts_in_det_plane_and_compute_ratio_in_corona(ANTEADATADIR, f
         df['tofpet_id'] = df['sensor_id'].apply(prf.tofpetid)
         evt_groupby     = ['event_id']
 
-    _, _, _, corona = prf.sensor_params(det_plane=True, coinc_plane_4tiles=False)
+    _, _, _, corona = prf.sensor_params(det_plane=det_plane)
 
-    df_cov  = prf.select_contained_evts(df, evt_groupby=evt_groupby)
+    df_cov  = prf.select_contained_evts(df, evt_groupby=evt_groupby, det_plane=det_plane)
     assert len(np.intersect1d(df_cov.sensor_id.unique(), corona))==0
 
-    ratio_cor = prf.compute_charge_ratio_in_corona(df_cov, evt_groupby=evt_groupby, variable=variable)
+    ratio_cor = prf.compute_charge_ratio_in_corona(df_cov, evt_groupby=evt_groupby, variable=variable, det_plane=det_plane)
     assert np.count_nonzero(ratio_cor.values)==0
 
-    ratios = prf.compute_charge_ratio_in_corona(df, evt_groupby=evt_groupby, variable=variable).values
+    ratios = prf.compute_charge_ratio_in_corona(df, evt_groupby=evt_groupby, variable=variable, det_plane=det_plane).values
     assert np.logical_and(ratios >= 0, ratios <= 1).all()

--- a/antea/reco/petit_reco_functions_test.py
+++ b/antea/reco/petit_reco_functions_test.py
@@ -32,16 +32,16 @@ def test_compute_coincidences(ANTEADATADIR, filename, data):
     assert np.all(s_d) and np.all(s_c)
 
 
-@mark.parametrize("filename data det_plane coinc_plane_1_tile variable tot_mode".split(),
-                  (('petit_mc_test.pet.h5', False, True,  True,          'charge', False),
-                   ('petit_mc_test.pet.h5', False, True, False,          'charge', False),
-                   ('petit_data_test.h5',    True, True,  True, 'efine_corrected', False),
-                   ('petit_data_test.h5',    True, True, False, 'efine_corrected', False),
-                   ('petit_data_test.h5',    True, True,  True,          'intg_w', False),
-                   ('petit_data_test.h5',    True, True,  True,      'intg_w_ToT',  True),
-                   ('petit_data_test.h5',    True, True, False,      'intg_w_ToT',  True)))
+@mark.parametrize("filename data det_plane coinc_plane_4tiles variable tot_mode".split(),
+                  (('petit_mc_test.pet.h5', False,  True, False,          'charge', False),
+                   ('petit_mc_test.pet.h5', False, False, False,          'charge', False),
+                   ('petit_data_test.h5',    True,  True, False, 'efine_corrected', False),
+                   ('petit_data_test.h5',    True, False, False, 'efine_corrected', False),
+                   ('petit_data_test.h5',    True,  True, False,          'intg_w', False),
+                   ('petit_data_test.h5',    True,  True, False,      'intg_w_ToT',  True),
+                   ('petit_data_test.h5',    True, False, False,      'intg_w_ToT',  True)))
 def test_select_evts_with_max_charge_at_center(ANTEADATADIR, filename, data, det_plane,
-                                               coinc_plane_1_tile, variable, tot_mode):
+                                               coinc_plane_4tiles, variable, tot_mode):
     """
     Checks that the max charge (in terms of the desired variable) is at center
     of the chosen plane.
@@ -56,20 +56,12 @@ def test_select_evts_with_max_charge_at_center(ANTEADATADIR, filename, data, det
         df['tofpet_id'] = df['sensor_id'].apply(prf.tofpetid)
         evt_groupby     = ['event_id']
 
-    if det_plane:
-        tofpet_id   = 0
-        central_sns = prf.central_sns_det
-    else:
-        tofpet_id   = 2
-        if coinc_plane_1_tile:
-            central_sns = prf.central_sns_coinc_1tile
-        else:
-            central_sns = prf.central_sns_coinc_4tiles
+    tofpet_id, central_sns, _, _ = prf.sensor_params(det_plane, coinc_plane_4tiles)
 
     df_center = prf.select_evts_with_max_charge_at_center(df,
                                                           evt_groupby        = evt_groupby,
                                                           det_plane          = det_plane,
-                                                          coinc_plane_1_tile = coinc_plane_1_tile,
+                                                          coinc_plane_4tiles = coinc_plane_4tiles,
                                                           variable           = variable,
                                                           tot_mode           = tot_mode)
     df_center = df_center[df_center.tofpet_id==tofpet_id]
@@ -101,8 +93,10 @@ def test_contained_evts_in_det_plane_and_compute_ratio_in_corona(ANTEADATADIR, f
         df['tofpet_id'] = df['sensor_id'].apply(prf.tofpetid)
         evt_groupby     = ['event_id']
 
-    df_cov  = prf.select_contained_evts_in_det_plane(df, evt_groupby=evt_groupby)
-    assert len(np.intersect1d(df_cov.sensor_id.unique(), prf.corona))==0
+    _, _, _, corona = prf.sensor_params(det_plane=True, coinc_plane_4tiles=False)
+
+    df_cov  = prf.select_contained_evts(df, evt_groupby=evt_groupby)
+    assert len(np.intersect1d(df_cov.sensor_id.unique(), corona))==0
 
     ratio_cor = prf.compute_charge_ratio_in_corona(df_cov, evt_groupby=evt_groupby, variable=variable)
     assert np.count_nonzero(ratio_cor.values)==0

--- a/antea/reco/petit_reco_functions_test.py
+++ b/antea/reco/petit_reco_functions_test.py
@@ -32,16 +32,16 @@ def test_compute_coincidences(ANTEADATADIR, filename, data):
     assert np.all(s_d) and np.all(s_c)
 
 
-@mark.parametrize("filename data det_plane variable tot_mode".split(),
-                  (('petit_mc_test.pet.h5', False,  True,          'charge', False),
-                   ('petit_mc_test.pet.h5', False, False,          'charge', False),
-                   ('petit_data_test.h5',    True,  True, 'efine_corrected', False),
-                   ('petit_data_test.h5',    True, False, 'efine_corrected', False),
-                   ('petit_data_test.h5',    True,  True,          'intg_w', False),
-                   ('petit_data_test.h5',    True,  True,      'intg_w_ToT',  True),
-                   ('petit_data_test.h5',    True, False,      'intg_w_ToT',  True)))
-def test_select_evts_with_max_charge_at_center(ANTEADATADIR, filename, data,
-                                               det_plane, variable, tot_mode):
+@mark.parametrize("filename data det_plane coinc_plane_1_tile variable tot_mode".split(),
+                  (('petit_mc_test.pet.h5', False, True,  True,          'charge', False),
+                   ('petit_mc_test.pet.h5', False, True, False,          'charge', False),
+                   ('petit_data_test.h5',    True, True,  True, 'efine_corrected', False),
+                   ('petit_data_test.h5',    True, True, False, 'efine_corrected', False),
+                   ('petit_data_test.h5',    True, True,  True,          'intg_w', False),
+                   ('petit_data_test.h5',    True, True,  True,      'intg_w_ToT',  True),
+                   ('petit_data_test.h5',    True, True, False,      'intg_w_ToT',  True)))
+def test_select_evts_with_max_charge_at_center(ANTEADATADIR, filename, data, det_plane,
+                                               coinc_plane_1_tile, variable, tot_mode):
     """
     Checks that the max charge (in terms of the desired variable) is at center
     of the chosen plane.
@@ -61,13 +61,17 @@ def test_select_evts_with_max_charge_at_center(ANTEADATADIR, filename, data,
         central_sns = prf.central_sns_det
     else:
         tofpet_id   = 2
-        central_sns = prf.central_sns_coinc
+        if coinc_plane_1_tile:
+            central_sns = prf.central_sns_coinc_1tile
+        else:
+            central_sns = prf.central_sns_coinc_4tiles
 
     df_center = prf.select_evts_with_max_charge_at_center(df,
-                                                          evt_groupby = evt_groupby,
-                                                          det_plane   = det_plane,
-                                                          variable    = variable,
-                                                          tot_mode    = tot_mode)
+                                                          evt_groupby        = evt_groupby,
+                                                          det_plane          = det_plane,
+                                                          coinc_plane_1_tile = coinc_plane_1_tile,
+                                                          variable           = variable,
+                                                          tot_mode           = tot_mode)
     df_center = df_center[df_center.tofpet_id==tofpet_id]
     assert len(df_center) > 0
 


### PR DESCRIPTION
The case of 4 tiles in the Coincidence plane was not included in `petit_reco_functions`. This PR fixes it by adding a new boolean parameter. In addition, a new function has been introduced to extract the parameters for each configuration (`det_plane`, `coinc_plane_4tiles`) and the function `select_contained_evts` ()with its corresponding test) has been extended to include the case for the coinc plane.